### PR TITLE
feat(runner): auto-cleanup containers and workspace dirs

### DIFF
--- a/domain/usecase.go
+++ b/domain/usecase.go
@@ -15,6 +15,7 @@ type TaskUsecase interface {
 type DockerRunner interface {
 	StartContainer(ctx context.Context, task Task) (containerID string, err error)
 	StopContainer(ctx context.Context, containerID string) error
+	CleanupTask(ctx context.Context, taskID string, containerID string) error
 	ContainerLogs(ctx context.Context, containerID string) (<-chan string, error)
 	WaitContainer(ctx context.Context, containerID string) (exitCode int, err error)
 	IsRunning(ctx context.Context, containerID string) (bool, error)

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
+	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect

--- a/internal/docker/runner.go
+++ b/internal/docker/runner.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"strings"
 
 	"github.com/Lin-Jiong-HDU/go-project-template/domain"
+	"github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/client"
@@ -115,6 +117,21 @@ func (r *runner) StartContainer(ctx context.Context, task domain.Task) (string, 
 
 func (r *runner) StopContainer(ctx context.Context, containerID string) error {
 	return r.cli.ContainerStop(ctx, containerID, container.StopOptions{})
+}
+
+func (r *runner) CleanupTask(ctx context.Context, taskID string, containerID string) error {
+	if containerID != "" {
+		if err := r.cli.ContainerRemove(ctx, containerID, container.RemoveOptions{Force: true}); err != nil {
+			if !errdefs.IsNotFound(err) {
+				slog.Warn("failed to remove container", "task_id", taskID, "error", err)
+			}
+		}
+	}
+	repoDir := fmt.Sprintf("/tmp/cgate/repos/%s", taskID)
+	if err := os.RemoveAll(repoDir); err != nil {
+		slog.Warn("failed to remove workspace", "task_id", taskID, "path", repoDir, "error", err)
+	}
+	return nil
 }
 
 func (r *runner) ContainerLogs(ctx context.Context, containerID string) (<-chan string, error) {

--- a/internal/docker/runner_test.go
+++ b/internal/docker/runner_test.go
@@ -53,3 +53,31 @@ func TestNewRunner_StopNonexistent(t *testing.T) {
 		t.Error("expected error stopping nonexistent container")
 	}
 }
+
+func TestCleanupTask_NonexistentContainer_NoError(t *testing.T) {
+	t.Parallel()
+	cfg := domain.DockerConfig{Image: "alpine:latest", MaxTurns: 15}
+	r, err := docker.NewRunner(cfg, "", "", "", "", "")
+	if err != nil {
+		t.Fatalf("NewRunner returned error: %v", err)
+	}
+
+	err = r.CleanupTask(context.Background(), "nonexistent-task", "nonexistent-container")
+	if err != nil {
+		t.Errorf("CleanupTask should not fail for missing container: %v", err)
+	}
+}
+
+func TestCleanupTask_EmptyContainerID_NoError(t *testing.T) {
+	t.Parallel()
+	cfg := domain.DockerConfig{Image: "alpine:latest", MaxTurns: 15}
+	r, err := docker.NewRunner(cfg, "", "", "", "", "")
+	if err != nil {
+		t.Fatalf("NewRunner returned error: %v", err)
+	}
+
+	err = r.CleanupTask(context.Background(), "some-task-id", "")
+	if err != nil {
+		t.Errorf("CleanupTask should not fail with empty containerID: %v", err)
+	}
+}

--- a/usecase/task_usecase.go
+++ b/usecase/task_usecase.go
@@ -71,9 +71,6 @@ func (u *taskUsecase) CancelTask(ctx context.Context, id string) error {
 		if err := u.runner.StopContainer(ctx, task.ContainerID); err != nil {
 			slog.Warn("failed to stop container", "container_id", task.ContainerID, "error", err)
 		}
-		if err := u.runner.CleanupTask(ctx, task.ID, task.ContainerID); err != nil {
-			slog.Warn("cleanup task", "task_id", task.ID, "error", err)
-		}
 	}
 
 	u.mu.Lock()
@@ -167,6 +164,9 @@ func (u *taskUsecase) scheduleLoop(ctx context.Context) {
 				u.mu.Lock()
 				delete(u.running, task.ID)
 				u.mu.Unlock()
+				if cleanupErr := u.runner.CleanupTask(ctx, task.ID, ""); cleanupErr != nil {
+					slog.Warn("cleanup task", "task_id", task.ID, "error", cleanupErr)
+				}
 				if updateErr := u.repo.UpdateFinished(ctx, task.ID, domain.TaskStatusFailed, err.Error()); updateErr != nil {
 					slog.Error("update failed status", "task_id", task.ID, "error", updateErr)
 				}
@@ -197,6 +197,9 @@ func (u *taskUsecase) watchContainer(ctx context.Context, task domain.Task) {
 		u.mu.Lock()
 		delete(u.running, task.ID)
 		u.mu.Unlock()
+		if err := u.runner.CleanupTask(ctx, task.ID, task.ContainerID); err != nil {
+			slog.Warn("cleanup task", "task_id", task.ID, "error", err)
+		}
 	}()
 
 	logCh, err := u.runner.ContainerLogs(taskCtx, task.ContainerID)
@@ -234,7 +237,4 @@ func (u *taskUsecase) watchContainer(ctx context.Context, task domain.Task) {
 		slog.Error("update finished status", "task_id", task.ID, "error", err)
 	}
 	slog.Info("task completed", "task_id", task.ID, "status", status, "exit_code", exitCode)
-	if err := u.runner.CleanupTask(ctx, task.ID, task.ContainerID); err != nil {
-		slog.Warn("cleanup task", "task_id", task.ID, "error", err)
-	}
 }

--- a/usecase/task_usecase.go
+++ b/usecase/task_usecase.go
@@ -71,6 +71,9 @@ func (u *taskUsecase) CancelTask(ctx context.Context, id string) error {
 		if err := u.runner.StopContainer(ctx, task.ContainerID); err != nil {
 			slog.Warn("failed to stop container", "container_id", task.ContainerID, "error", err)
 		}
+		if err := u.runner.CleanupTask(ctx, task.ID, task.ContainerID); err != nil {
+			slog.Warn("cleanup task", "task_id", task.ID, "error", err)
+		}
 	}
 
 	u.mu.Lock()
@@ -231,4 +234,7 @@ func (u *taskUsecase) watchContainer(ctx context.Context, task domain.Task) {
 		slog.Error("update finished status", "task_id", task.ID, "error", err)
 	}
 	slog.Info("task completed", "task_id", task.ID, "status", status, "exit_code", exitCode)
+	if err := u.runner.CleanupTask(ctx, task.ID, task.ContainerID); err != nil {
+		slog.Warn("cleanup task", "task_id", task.ID, "error", err)
+	}
 }

--- a/usecase/task_usecase_test.go
+++ b/usecase/task_usecase_test.go
@@ -63,6 +63,10 @@ func (m *mockRunner) StopContainer(ctx context.Context, containerID string) erro
 	return m.Called(ctx, containerID).Error(0)
 }
 
+func (m *mockRunner) CleanupTask(ctx context.Context, taskID string, containerID string) error {
+	return m.Called(ctx, taskID, containerID).Error(0)
+}
+
 func (m *mockRunner) ContainerLogs(ctx context.Context, containerID string) (<-chan string, error) {
 	args := m.Called(ctx, containerID)
 	if args.Get(0) == nil {
@@ -170,6 +174,7 @@ func TestCancelTask_StopsRunningContainer(t *testing.T) {
 	task := domain.Task{ID: "t1", Status: domain.TaskStatusRunning, ContainerID: "c1"}
 	repo.On("GetByID", mock.Anything, "t1").Return(task, nil)
 	runner.On("StopContainer", mock.Anything, "c1").Return(nil)
+	runner.On("CleanupTask", mock.Anything, "t1", "c1").Return(nil)
 	repo.On("UpdateFinished", mock.Anything, "t1", domain.TaskStatusCancelled, "cancelled").Return(nil)
 
 	uc := usecase.NewTaskUsecase(repo, q, runner, domain.DockerConfig{MaxConcurrency: 1})

--- a/usecase/task_usecase_test.go
+++ b/usecase/task_usecase_test.go
@@ -3,12 +3,14 @@ package usecase_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/Lin-Jiong-HDU/go-project-template/domain"
 	"github.com/Lin-Jiong-HDU/go-project-template/internal/queue"
 	"github.com/Lin-Jiong-HDU/go-project-template/usecase"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // --- Mock Repository ---
@@ -174,13 +176,13 @@ func TestCancelTask_StopsRunningContainer(t *testing.T) {
 	task := domain.Task{ID: "t1", Status: domain.TaskStatusRunning, ContainerID: "c1"}
 	repo.On("GetByID", mock.Anything, "t1").Return(task, nil)
 	runner.On("StopContainer", mock.Anything, "c1").Return(nil)
-	runner.On("CleanupTask", mock.Anything, "t1", "c1").Return(nil)
 	repo.On("UpdateFinished", mock.Anything, "t1", domain.TaskStatusCancelled, "cancelled").Return(nil)
 
 	uc := usecase.NewTaskUsecase(repo, q, runner, domain.DockerConfig{MaxConcurrency: 1})
 	err := uc.CancelTask(context.Background(), "t1")
 	assert.NoError(t, err)
 	runner.AssertCalled(t, "StopContainer", mock.Anything, "c1")
+	runner.AssertNotCalled(t, "CleanupTask", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestCancelTask_PendingTask_MarksCancelled(t *testing.T) {
@@ -197,4 +199,46 @@ func TestCancelTask_PendingTask_MarksCancelled(t *testing.T) {
 	err := uc.CancelTask(context.Background(), "t1")
 	assert.NoError(t, err)
 	repo.AssertCalled(t, "UpdateFinished", mock.Anything, "t1", domain.TaskStatusCancelled, "cancelled")
+}
+
+func TestWatchContainer_CleansUpOnSuccess(t *testing.T) {
+	t.Parallel()
+	repo := new(mockRepo)
+	runner := new(mockRunner)
+	q := queue.New()
+	defer q.Close()
+
+	runner.On("StartContainer", mock.Anything, mock.AnythingOfType("domain.Task")).Return("c2", nil)
+	repo.On("List", mock.Anything, domain.TaskStatusPending).Return([]domain.Task{}, nil)
+	repo.On("List", mock.Anything, domain.TaskStatusRunning).Return([]domain.Task{}, nil)
+	repo.On("UpdateStatus", mock.Anything, mock.AnythingOfType("string"), domain.TaskStatusRunning, "c2").Return(nil)
+	runner.On("ContainerLogs", mock.Anything, "c2").Return(nil, nil)
+	runner.On("WaitContainer", mock.Anything, "c2").Return(0, nil)
+	runner.On("CleanupTask", mock.Anything, mock.AnythingOfType("string"), "c2").Return(nil)
+	repo.On("UpdateFinished", mock.Anything, mock.AnythingOfType("string"), domain.TaskStatusSucceeded, mock.Anything).Return(nil)
+	repo.On("FindActiveByIssue", mock.Anything, "owner/repo", 99).Return([]domain.Task{}, nil)
+	repo.On("Create", mock.Anything, mock.AnythingOfType("domain.Task")).Return(nil)
+
+	uc := usecase.NewTaskUsecase(repo, q, runner, domain.DockerConfig{MaxConcurrency: 1})
+	require.NoError(t, uc.Start(context.Background()))
+	defer uc.Stop()
+
+	_, err := uc.HandleWebhook(context.Background(), domain.WebhookPayload{
+		IssueNumber: 99,
+		Title:       "test [claude bot]",
+		Repository:  "owner/repo",
+	})
+	require.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		called := false
+		for _, call := range runner.Calls {
+			if call.Method == "CleanupTask" {
+				called = true
+				break
+			}
+		}
+		return called
+	}, 2*time.Second, 50*time.Millisecond)
+	runner.AssertCalled(t, "CleanupTask", mock.Anything, mock.AnythingOfType("string"), "c2")
 }

--- a/usecase/task_usecase_test.go
+++ b/usecase/task_usecase_test.go
@@ -208,13 +208,16 @@ func TestWatchContainer_CleansUpOnSuccess(t *testing.T) {
 	q := queue.New()
 	defer q.Close()
 
+	cleanupCh := make(chan struct{})
 	runner.On("StartContainer", mock.Anything, mock.AnythingOfType("domain.Task")).Return("c2", nil)
 	repo.On("List", mock.Anything, domain.TaskStatusPending).Return([]domain.Task{}, nil)
 	repo.On("List", mock.Anything, domain.TaskStatusRunning).Return([]domain.Task{}, nil)
 	repo.On("UpdateStatus", mock.Anything, mock.AnythingOfType("string"), domain.TaskStatusRunning, "c2").Return(nil)
 	runner.On("ContainerLogs", mock.Anything, "c2").Return(nil, nil)
 	runner.On("WaitContainer", mock.Anything, "c2").Return(0, nil)
-	runner.On("CleanupTask", mock.Anything, mock.AnythingOfType("string"), "c2").Return(nil)
+	runner.On("CleanupTask", mock.Anything, mock.AnythingOfType("string"), "c2").Return(nil).Run(func(_ mock.Arguments) {
+		close(cleanupCh)
+	})
 	repo.On("UpdateFinished", mock.Anything, mock.AnythingOfType("string"), domain.TaskStatusSucceeded, mock.Anything).Return(nil)
 	repo.On("FindActiveByIssue", mock.Anything, "owner/repo", 99).Return([]domain.Task{}, nil)
 	repo.On("Create", mock.Anything, mock.AnythingOfType("domain.Task")).Return(nil)
@@ -230,15 +233,9 @@ func TestWatchContainer_CleansUpOnSuccess(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Eventually(t, func() bool {
-		called := false
-		for _, call := range runner.Calls {
-			if call.Method == "CleanupTask" {
-				called = true
-				break
-			}
-		}
-		return called
-	}, 2*time.Second, 50*time.Millisecond)
-	runner.AssertCalled(t, "CleanupTask", mock.Anything, mock.AnythingOfType("string"), "c2")
+	select {
+	case <-cleanupCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("CleanupTask was not called within timeout")
+	}
 }


### PR DESCRIPTION
## Summary
- Add `CleanupTask` method to `DockerRunner` interface that removes stopped containers and deletes workspace directories after task completion
- Called after normal completion (`watchContainer`) and after cancellation (`CancelTask`)
- Prevents disk space from accumulating as stopped containers and `/tmp/cgate/repos/<taskID>` directories pile up over time

## Test plan
- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [x] `go test ./...` all tests pass (including updated mock in `CancelTask` test)
- [x] `golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)