### PR TITLE
fix(runner): pin golangci-lint version in runner image

### DIFF
--- a/runner-image/Dockerfile
+++ b/runner-image/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-    | sh -s -- -b $(go env GOPATH)/bin latest
+    | sh -s -- -b $(go env GOPATH)/bin v2.0.2
 
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \


### PR DESCRIPTION
## Summary
- `golangci-lint` install script fails to resolve the `latest` tag on the server due to network/GitHub API issues
- Pin to `v2.0.2` for reproducible builds

## Test plan
- [x] Build runner image on server: `cd runner-image && docker build -t claude-code-runner:latest .`
- [x] Verify golangci-lint installs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)