### PR TITLE
fix(webhook): handle special characters in issue title and body

### DIFF
--- a/.github/workflows/issue-webhook.yml
+++ b/.github/workflows/issue-webhook.yml
@@ -17,18 +17,27 @@ jobs:
 
     steps:
       - name: Send issue to webhook
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_REPO: ${{ github.repository }}
+          ISSUE_CREATED: ${{ github.event.issue.created_at }}
+          ISSUE_LABELS_JSON: ${{ toJson(github.event.issue.labels.*.name) }}
         run: |
-          curl -sf -X POST "${{ secrets.WEBHOOK_URL }}" \
+          jq -n \
+            --arg action "opened" \
+            --argjson issue_number ${{ github.event.issue.number }} \
+            --arg title "$ISSUE_TITLE" \
+            --arg body "$ISSUE_BODY" \
+            --arg author "$ISSUE_AUTHOR" \
+            --argjson labels "$ISSUE_LABELS_JSON" \
+            --arg url "$ISSUE_URL" \
+            --arg repository "$ISSUE_REPO" \
+            --arg created_at "$ISSUE_CREATED" \
+            '{action: $action, issue_number: $issue_number, title: $title, body: $body, author: $author, labels: $labels, url: $url, repository: $repository, created_at: $created_at}' \
+          | curl -sf -X POST "${{ secrets.WEBHOOK_URL }}" \
             -H "Content-Type: application/json" \
             -H "X-Webhook-Secret: ${{ secrets.WEBHOOK_SECRET }}" \
-            -d '{
-                "action": "opened",
-                "issue_number": ${{ github.event.issue.number }},
-                "title": ${{ toJson(github.event.issue.title) }},
-                "body": ${{ toJson(github.event.issue.body) }},
-                "author": "${{ github.event.issue.user.login }}",
-                "labels": ${{ toJson(github.event.issue.labels.*.name) }},
-                "url": "${{ github.event.issue.html_url }}",
-                "repository": "${{ github.repository }}",
-                "created_at": "${{ github.event.issue.created_at }}"
-              }'
+            -d @-

--- a/.github/workflows/pr-review-webhook.yml
+++ b/.github/workflows/pr-review-webhook.yml
@@ -19,19 +19,26 @@ jobs:
 
     steps:
       - name: Send PR review to webhook
+        env:
+          PR_TITLE: ${{ github.event.issue.title }}
+          PR_BODY: ${{ github.event.comment.body }}
+          PR_AUTHOR: ${{ github.event.comment.user.login }}
+          PR_URL: ${{ github.event.issue.html_url }}
+          PR_REPO: ${{ github.repository }}
+          PR_CREATED: ${{ github.event.comment.created_at }}
         run: |
-          curl -sf -X POST "${{ secrets.WEBHOOK_URL }}" \
+          jq -n \
+            --arg action "created" \
+            --argjson pr_number ${{ github.event.issue.number }} \
+            --argjson comment_id ${{ github.event.comment.id }} \
+            --arg title "$PR_TITLE" \
+            --arg body "$PR_BODY" \
+            --arg author "$PR_AUTHOR" \
+            --arg url "$PR_URL" \
+            --arg repository "$PR_REPO" \
+            --arg created_at "$PR_CREATED" \
+            '{action: $action, trigger_type: "pr_review", pr_number: $pr_number, comment_id: $comment_id, title: $title, body: $body, author: $author, url: $url, repository: $repository, created_at: $created_at}' \
+          | curl -sf -X POST "${{ secrets.WEBHOOK_URL }}" \
             -H "Content-Type: application/json" \
             -H "X-Webhook-Secret: ${{ secrets.WEBHOOK_SECRET }}" \
-            -d '{
-                "action": "created",
-                "trigger_type": "pr_review",
-                "pr_number": ${{ github.event.issue.number }},
-                "comment_id": ${{ github.event.comment.id }},
-                "title": ${{ toJson(github.event.issue.title) }},
-                "body": ${{ toJson(github.event.comment.body) }},
-                "author": "${{ github.event.comment.user.login }}",
-                "url": "${{ github.event.issue.html_url }}",
-                "repository": "${{ github.repository }}",
-                "created_at": "${{ github.event.comment.created_at }}"
-              }'
+            -d @-

--- a/internal/docker/runner.go
+++ b/internal/docker/runner.go
@@ -210,12 +210,13 @@ func SanitizeEnvValue(s string) string {
 	return b.String()
 }
 
-// SanitizeShellValue strips shell command substitution patterns in addition to
-// control characters. Used for fields that flow into shell scripts where
-// expansion could occur (e.g., issue titles used in heredocs).
+// SanitizeShellValue strips shell expansion patterns in addition to control
+// characters. Used for fields that flow into shell scripts where expansion
+// could occur (e.g., issue titles used in heredocs).
 func SanitizeShellValue(s string) string {
 	s = SanitizeEnvValue(s)
 	s = strings.ReplaceAll(s, "$(", "")
+	s = strings.ReplaceAll(s, "${", "")
 	s = strings.ReplaceAll(s, "`", "")
 	return s
 }

--- a/runner-image/entrypoint.sh
+++ b/runner-image/entrypoint.sh
@@ -38,7 +38,7 @@ run_issue() {
     for i in 1 2 3; do git pull origin main && break || sleep 5; done
     git checkout -b "$branch"
 
-    envsubst < /prompt-template.txt > /tmp/prompt.txt
+    envsubst '${ISSUE_NUMBER} ${ISSUE_TITLE} ${ISSUE_BODY} ${REPOSITORY} ${ISSUE_URL} ${branch}' < /prompt-template.txt > /tmp/prompt.txt
 
     claude_args=(-p "$(cat /tmp/prompt.txt)")
     if [ "${SKIP_PERMISSIONS:-}" = "true" ]; then
@@ -137,7 +137,7 @@ run_pr_review() {
 }
 REVIEWEOF
 
-    envsubst < /prompt-template-pr-review.txt > /tmp/prompt.txt
+    envsubst '${PR_NUMBER} ${REPOSITORY} ${pr_branch}' < /prompt-template-pr-review.txt > /tmp/prompt.txt
 
     claude_args=(-p "$(cat /tmp/prompt.txt)")
     if [ "${SKIP_PERMISSIONS:-}" = "true" ]; then


### PR DESCRIPTION
## Summary

- **Root cause**: GitHub Actions workflow 用 `curl -d '...'` 单引号包裹 JSON payload，当 issue 标题或正文包含单引号（如 `It's a bug`）时，shell 引号配对被打破，导致 webhook 发送失败
- 使用 `jq --arg` + 环境变量安全构造 JSON payload，彻底避免 shell 引号问题
- 限制 `envsubst` 只扩展模板中已知的变量名，防止 `${VAR}` 意外扩展
- 在 `SanitizeShellValue` 中增加 `${` 模式剥离，纵深防御

## Changes

| File | Change |
|------|--------|
| `.github/workflows/issue-webhook.yml` | 用 `jq -n --arg` 替代手动 JSON 构建 |
| `.github/workflows/pr-review-webhook.yml` | 同上 |
| `internal/docker/runner.go` | `SanitizeShellValue` 增加 `${` 剥离 |
| `runner-image/entrypoint.sh` | `envsubst` 指定明确的变量列表 |

## Test plan

- [x] `go vet ./...` 通过
- [x] `go build ./...` 通过
- [x] `go test ./...` 通过
- [x] `golangci-lint run` 通过
- [x] 创建包含单引号/特殊字符的 issue（如 `It's a bug (urgent) $100 [claude bot]`）验证 webhook 正常触发

🤖 Generated with [Claude Code](https://claude.com/claude-code)